### PR TITLE
First word problems when tailing.

### DIFF
--- a/bin/ajour.js
+++ b/bin/ajour.js
@@ -8,7 +8,7 @@ var minimist = require('minimist');
 // Douglas Crockford Object creation style
 var Ajour = function () {
 	// get argumentents
-	var argv = minimist(process.argv.slice(2));
+	var argv = minimist(process.argv.slice(2), {boolean: 't'});
 
 	// include timestamp unless -t flag set
 	var timestamp = argv.t ? "" : '\n# ' + new Date() +'\n';


### PR DESCRIPTION
The first word is missing from the output when ajour is run with -t before the text.

```
ajour -t one two three -> two three 
ajour -t "Never to be seen again" -> Nothing
```
