### PR TITLE
Update package.json license to match root license.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "minimist":"1.1.0"
   },
   "author": "Patrik Gothe",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gopatrik/ajour/issues"
   },


### PR DESCRIPTION
The license in root (MIT) was not reflected here, I imagine because it was pre filled here during 'npm init'.
