### PR TITLE
Remove unnecessary code.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
   "name": "ajour",
   "version": "0.0.3",
   "description": "A simple command line journaling tool",
-  "bin": {
-    "ajour": "bin/ajour.js"
-  },
+  "bin": "bin/ajour.js",
   "scripts": {
     "test": "echo \\\"Error: no test specified\\\" && exit 1"
   },


### PR DESCRIPTION
As there is a single executable with the same name as the package, excess code can be removed. - resubmitted due to typo.
